### PR TITLE
argo: fixing libargo

### DIFF
--- a/pkg/argo/argo-libargo.go
+++ b/pkg/argo/argo-libargo.go
@@ -1,3 +1,4 @@
+package argo
 // +build libargo
 
 // #cgo LDFLAGS: -largo


### PR DESCRIPTION
The argo-libargo.go file was missing its package declaration.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>