### PR TITLE
argo: correcting package label

### DIFF
--- a/pkg/argo/argo-libargo.go
+++ b/pkg/argo/argo-libargo.go
@@ -1,6 +1,6 @@
-package argo
 // +build libargo
 
+package argo
 // #cgo LDFLAGS: -largo
 // #include <libargo.h>
 // #include <errno.h>


### PR DESCRIPTION
Package declaration was place in the incorrect line, breaking build tag.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>