### PR TITLE
argo: moved to versioned godbus

### DIFF
--- a/cmd/dbus-send/main.go
+++ b/cmd/dbus-send/main.go
@@ -10,7 +10,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 	"github.com/openxt/openxt-go/pkg/argo/dbus"
-	godbus "github.com/godbus/dbus"
+	godbus "github.com/godbus/dbus/v5"
 )
 
 var (

--- a/pkg/argo/argo-libargo.go
+++ b/pkg/argo/argo-libargo.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"syscall"
 	"fmt"
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
     )
 
 func libargo_socket(ct C.int) (res C.int, err error) {

--- a/pkg/argo/go.mod
+++ b/pkg/argo/go.mod
@@ -1,3 +1,5 @@
 module github.com/openxt/openxt-go/pkg/argo
 
 go 1.12
+
+require github.com/godbus/dbus/v5 v5.0.3

--- a/pkg/argo/go.sum
+++ b/pkg/argo/go.sum
@@ -1,0 +1,2 @@
+github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
+github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/pkg/dbd/dbd.go
+++ b/pkg/dbd/dbd.go
@@ -4,7 +4,7 @@
 package dbd
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 type Client interface {


### PR DESCRIPTION
Move to using semantic version 5 of godbus.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>