### PR TITLE
mod: rework go modules definitions

### DIFF
--- a/cmd/dbdcmd/main.go
+++ b/cmd/dbdcmd/main.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/apertussolutions/openxt-go/dbd"
+	"github.com/openxt/openxt-go/pkg/dbd"
 )
 
 func die(format string, a ...interface{}) {

--- a/cmd/xenstore/main.go
+++ b/cmd/xenstore/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/apertussolutions/openxt-go/xenstore"
+	"github.com/openxt/openxt-go/pkg/xenstore"
 )
 
 func die(format string, a ...interface{}) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/openxt/openxt-go
+
+go 1.12
+
+require (
+	github.com/godbus/dbus/v5 v5.0.3
+	github.com/spf13/pflag v1.0.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/pkg/argo/go.mod
+++ b/pkg/argo/go.mod
@@ -1,5 +1,0 @@
-module github.com/openxt/openxt-go/pkg/argo
-
-go 1.12
-
-require github.com/godbus/dbus/v5 v5.0.3

--- a/pkg/dbd/go.mod
+++ b/pkg/dbd/go.mod
@@ -1,3 +1,0 @@
-module github.com/openxt/openxt-go/pkg/dbd
-
-go 1.12

--- a/pkg/xenstore/go.mod
+++ b/pkg/xenstore/go.mod
@@ -1,3 +1,0 @@
-module github.com/openxt/openxt-go/pkg/xenstore
-
-go 1.12


### PR DESCRIPTION
This fixes the current go modules setup to follow common practices
and prepare for moving to OpenXT Github organization.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>