### PR TITLE
actions: setup a build check action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,27 @@
+name: Build Check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        go-version: [1.14, 1.15, 1.16, 1.17]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.go-version}}
+
+    - name: Build
+      run: go build -v ./...


### PR DESCRIPTION
This will set up a basic build for every version of Go starting with the version used by the current target OE release.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>